### PR TITLE
Unify the file name to plugin.wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-oidc.wasm
-plugin.wasm
+*.wasm
 
 
 #Added by cargo

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ plugin.wasm:
 	@cargo build --target wasm32-unknown-unknown --release
 	@cp target/wasm32-unknown-unknown/release/oidc_filter.wasm ./plugin.wasm
 
-image: oidc.wasm
+image: plugin.wasm
 	@echo \#\#\# Building container...
 	@${CONTAINER_CLI} build -f container/Dockerfile . -t oidc-filter
 

--- a/examples/envoy/Dockerfile
+++ b/examples/envoy/Dockerfile
@@ -1,4 +1,4 @@
 FROM envoyproxy/envoy-alpine:v1.17-latest
 
 COPY examples/envoy/envoy.yaml /etc/envoy/envoy.yaml
-COPY oidc.wasm /var/local/lib/wasm-filters/oidc.wasm
+COPY plugin.wasm /var/local/lib/wasm-filters/plugin.wasm

--- a/examples/envoy/envoy.yaml
+++ b/examples/envoy/envoy.yaml
@@ -53,7 +53,7 @@ static_resources:
                   vmConfig:
                     code:
                       local:
-                        filename: /var/local/lib/wasm-filters/oidc.wasm
+                        filename: /var/local/lib/wasm-filters/plugin.wasm
                     runtime: envoy.wasm.runtime.v8
                     vmId: oidc-filter
                     allow_precompiled: true

--- a/examples/istio/deploy.sh
+++ b/examples/istio/deploy.sh
@@ -13,7 +13,7 @@ kubectl apply -f httpbin-gateway.yaml
 
 kubectl rollout status deployment/httpbin
 HTTPBIN_POD=$(kubectl get pods -lapp=httpbin -o jsonpath='{.items[0].metadata.name}')
-kubectl cp ../oidc.wasm  ${HTTPBIN_POD}:/var/local/lib/wasm-filters/oidc.wasm --container istio-proxy
+kubectl cp ../plugin.wasm  ${HTTPBIN_POD}:/var/local/lib/wasm-filters/plugin.wasm --container istio-proxy
 
 kubectl apply -f istio-auth.yaml
 sed -e "s/INSERT_CLIENT_SECRET_HERE/${CLIENT_SECRET}/" envoyfilter.yaml | kubectl apply -f -

--- a/examples/istio/envoyfilter.yaml
+++ b/examples/istio/envoyfilter.yaml
@@ -40,7 +40,7 @@ spec:
               vmConfig:
                 code:
                   local:
-                    filename: /var/local/lib/wasm-filters/oidc.wasm
+                    filename: /var/local/lib/wasm-filters/plugin.wasm
                 runtime: envoy.wasm.runtime.v8
                 vmId: oidc-filter
                 allow_precompiled: true


### PR DESCRIPTION
Sorry if I am missing something, but it appears that the names `oidc.wasm` and `plugin.wasm` are mixed up.
Trying to run the envoy example did not work.

Since `plugin.wasm` was introduced later, I think we can support that one.
https://github.com/dgn/oidc-filter/pull/11